### PR TITLE
Add `Cost: Free` for all OS and Freeware records

### DIFF
--- a/records/3d-ptv.yaml
+++ b/records/3d-ptv.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Laboratory
+Cost: Free
 Country of Origin:
   - International
 Developer: ETH Zurich

--- a/records/avl.yaml
+++ b/records/avl.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Description: |-

--- a/records/bemrosetta.yaml
+++ b/records/bemrosetta.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Inaki Zabala

--- a/records/bemuse.yaml
+++ b/records/bemuse.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Joseph Saverin

--- a/records/cactus-tools.yaml
+++ b/records/cactus-tools.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Dependencies: CACTUS

--- a/records/cactus.yaml
+++ b/records/cactus.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Sandia National Labs

--- a/records/capytaine.yaml
+++ b/records/capytaine.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Matthieu Ancellin

--- a/records/ccblade.yaml
+++ b/records/ccblade.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: NREL

--- a/records/cn-stream.yaml
+++ b/records/cn-stream.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Ecole Centrale de Nantes

--- a/records/coastlib.yaml
+++ b/records/coastlib.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Georgii Bocharov

--- a/records/code-saturne.yaml
+++ b/records/code-saturne.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: EDF

--- a/records/convergence.yaml
+++ b/records/convergence.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Mathew Topper

--- a/records/d3d-add-turbines.yaml
+++ b/records/d3d-add-turbines.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Simon Waldman

--- a/records/delft3d-flexible-mesh-suite.yaml
+++ b/records/delft3d-flexible-mesh-suite.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Description: |-

--- a/records/delft3d-fm-cec.yaml
+++ b/records/delft3d-fm-cec.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Sandia National Labs

--- a/records/delft3dfmpy.yaml
+++ b/records/delft3dfmpy.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Dependencies: Delft3D Flexible Mesh Suite

--- a/records/dfm-tools.yaml
+++ b/records/dfm-tools.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Dependencies: Delft3D Flexible Mesh Suite

--- a/records/diwasp.yaml
+++ b/records/diwasp.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: The University of Western Australia

--- a/records/dolfyn.yaml
+++ b/records/dolfyn.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Field
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: NREL

--- a/records/dtocean.yaml
+++ b/records/dtocean.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Discipline:

--- a/records/dtoceanplus.yaml
+++ b/records/dtoceanplus.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Description: |-

--- a/records/dualsphysics.yaml
+++ b/records/dualsphysics.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: DualSPHysics Group

--- a/records/essc.yaml
+++ b/records/essc.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Sandia

--- a/records/eyesea.yaml
+++ b/records/eyesea.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Field
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: PNNL

--- a/records/fluidimage.yaml
+++ b/records/fluidimage.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Laboratory
+Cost: Free
 Country of Origin:
   - International
 Developer: Pierre Augier

--- a/records/fluidity.yaml
+++ b/records/fluidity.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Dr Christopher C. Pain

--- a/records/fluidlab.yaml
+++ b/records/fluidlab.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Laboratory
+Cost: Free
 Country of Origin:
   - International
 Developer: Pierre Augier

--- a/records/fluidsim-ocean.yaml
+++ b/records/fluidsim-ocean.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Dependencies: Fluidsim

--- a/records/fluidsim.yaml
+++ b/records/fluidsim.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Pierre Augier

--- a/records/foamm.yaml
+++ b/records/foamm.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Description: |-

--- a/records/frydom-ce.yaml
+++ b/records/frydom-ce.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: DICE-Engineering

--- a/records/full-scale-model-mhk.yaml
+++ b/records/full-scale-model-mhk.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Dependencies: ANSYS Fluent

--- a/records/gazebo-waves.yaml
+++ b/records/gazebo-waves.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Dependencies: Gazebo Sim

--- a/records/gazebo.yaml
+++ b/records/gazebo.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Open Robotics

--- a/records/gmsh.yaml
+++ b/records/gmsh.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Description: |-

--- a/records/gpusph.yaml
+++ b/records/gpusph.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Discipline:

--- a/records/gridapps-d.yaml
+++ b/records/gridapps-d.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Field
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Pacific Northwest National Laboratory

--- a/records/hams.yaml
+++ b/records/hams.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: 'Yingyi Liu '

--- a/records/harp-opt.yaml
+++ b/records/harp-opt.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: NREL

--- a/records/helyx-os.yaml
+++ b/records/helyx-os.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Dependencies: OpenFOAM

--- a/records/hos-nwt.yaml
+++ b/records/hos-nwt.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Ecole Centrale de Nantes

--- a/records/hos-ocean.yaml
+++ b/records/hos-ocean.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Ecole Centrale de Nantes

--- a/records/hulme-heaving-sphere.yaml
+++ b/records/hulme-heaving-sphere.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Ecole Centrale de Nantes

--- a/records/image-based-velocimetry-toolbox.yaml
+++ b/records/image-based-velocimetry-toolbox.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Laboratory
+Cost: Free
 Country of Origin:
   - International
 Developer: Matthias Kramer

--- a/records/jpiv.yaml
+++ b/records/jpiv.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Laboratory
+Cost: Free
 Country of Origin:
   - International
 Developer: Peter Vennemann

--- a/records/libdelhommeau.yaml
+++ b/records/libdelhommeau.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Matthieu Ancellin

--- a/records/lily-pad.yaml
+++ b/records/lily-pad.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Dr G D Weymouth

--- a/records/mace.yaml
+++ b/records/mace.yaml
@@ -1,6 +1,7 @@
 Collection Method:
   - Field
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Description: |-

--- a/records/map.yaml
+++ b/records/map.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: NREL

--- a/records/matpower.yaml
+++ b/records/matpower.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: The MATPOWER team

--- a/records/me-grid-lite.yaml
+++ b/records/me-grid-lite.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: University of North Carolina

--- a/records/me-grid.yaml
+++ b/records/me-grid.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Description: |-

--- a/records/meshmagick.yaml
+++ b/records/meshmagick.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: ECN

--- a/records/mhkit-matlab.yaml
+++ b/records/mhkit-matlab.yaml
@@ -1,6 +1,7 @@
 Collection Method:
   - Field
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: MHKiT

--- a/records/mhkit-python.yaml
+++ b/records/mhkit-python.yaml
@@ -1,6 +1,7 @@
 Collection Method:
   - Field
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: MHKiT

--- a/records/migrids.yaml
+++ b/records/migrids.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Alaska Center for Energy and Power

--- a/records/mike-add-turbines.yaml
+++ b/records/mike-add-turbines.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Dependencies: MIKE21/3

--- a/records/mike-tools.yaml
+++ b/records/mike-tools.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Dependencies: MIKE21/3

--- a/records/moodymarine.yaml
+++ b/records/moodymarine.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Dependencies: NEMOH
@@ -27,10 +28,10 @@ Primary Use:
 Programming Language:
   - C++
   - JavaScript
+TRL:
+  - 1-3
+  - 4-6
 Technology:
   - Wave
 Title: MoodyMarine
-TRL:
-  - "1-3"
-  - "4-6"
 Web Address: https://www.moodymarine.se/

--- a/records/moordyn.yaml
+++ b/records/moordyn.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: NREL

--- a/records/mss-marine-systems-simulator.yaml
+++ b/records/mss-marine-systems-simulator.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Thor I. Fossen

--- a/records/mtmc.yaml
+++ b/records/mtmc.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Dependencies: MIKE21/3

--- a/records/mwave.yaml
+++ b/records/mwave.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Cameron McNatt

--- a/records/ndbc.yaml
+++ b/records/ndbc.yaml
@@ -1,6 +1,7 @@
 Collection Method:
   - Field
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Wavebit Scientific LLC

--- a/records/nemoh.yaml
+++ b/records/nemoh.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: ECN

--- a/records/noaa-coops.yaml
+++ b/records/noaa-coops.yaml
@@ -1,6 +1,7 @@
 Collection Method:
   - Field
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Greg Clunies

--- a/records/oceaned.yaml
+++ b/records/oceaned.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: David Forehand

--- a/records/oceanlyz.yaml
+++ b/records/oceanlyz.yaml
@@ -1,6 +1,7 @@
 Collection Method:
   - Field
   - Laboratory
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Arash Karimpour

--- a/records/oceanmesh2d.yaml
+++ b/records/oceanmesh2d.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Keith Roberts

--- a/records/oceanwave3d-fortran90.yaml
+++ b/records/oceanwave3d-fortran90.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Allan P. Engsig-Karup

--- a/records/oceanwaves-python.yaml
+++ b/records/oceanwaves-python.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: OpenEarth

--- a/records/oceanwaves.yaml
+++ b/records/oceanwaves.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Field
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Luke Miller

--- a/records/olaflow.yaml
+++ b/records/olaflow.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Pablo Higuera

--- a/records/openfast.yaml
+++ b/records/openfast.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: NREL

--- a/records/openfoam.yaml
+++ b/records/openfoam.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Description: |-

--- a/records/openmdao.yaml
+++ b/records/openmdao.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: NASA Glenn Research Center

--- a/records/openmoor.yaml
+++ b/records/openmoor.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Lin Chen

--- a/records/openptv.yaml
+++ b/records/openptv.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Laboratory
+Cost: Free
 Country of Origin:
   - International
 Developer: OpenPTV Consortium

--- a/records/opentidalfarm.yaml
+++ b/records/opentidalfarm.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Simon Funke

--- a/records/openwec.yaml
+++ b/records/openwec.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Tim Verbrugghe

--- a/records/opie.yaml
+++ b/records/opie.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Laboratory
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: UNH-OE
@@ -13,21 +14,6 @@ License Type:
       - MIT
 Life Cycle:
   - Design
-Note: "OPIE was developed some time ago, and motion tracking software has become very\
-  \ commonplace since. Kinovea is one example. \nThe UNH OPIE system \u201Clives\u201D\
-  \ on a dedicated cart with a desktop computer and also on a laptop in a Pelican\
-  \ case, with dedicated cameras, but hasn\u2019t been used in these configurations\
-  \ in a couple of years \u2013 this means these particular systems would need to\
-  \ be evaluated for functionality. I\u2019m copying John Ahern, our OE Lab engineer\
-  \ who will be involved in the testing.\n\nThe most important part in optical tracking\
-  \ is to obtain good video and follow best practices in establishing high-contrast\
-  \ points on a model that can be. Any camera can be used. The UNH wave/tow tank has\
-  \ windows on the side and on the bottom, and video/tracking can also be done from\
-  \ above. Most of the time motion tracking in waves has been done with a camera pointed\
-  \ through the side window.\n\nUNH is committed to providing an appropriate camera\
-  \ and lighting (if necessary) to obtain good video for motion tracking analysis.\
-  \  Motion tracking can then be done with the Matlab-based OPIE (code in github repository\
-  \ above) or other motion tracking software. \n"
 Primary Use:
   - Other
 Programming Language:

--- a/records/pangeo-pytide.yaml
+++ b/records/pangeo-pytide.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: "Fr\xE9d\xE9ric BRIOL"

--- a/records/paracousti.yaml
+++ b/records/paracousti.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Sandia

--- a/records/pecos.yaml
+++ b/records/pecos.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Field
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Sandia

--- a/records/piv.yaml
+++ b/records/piv.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Laboratory
+Cost: Free
 Country of Origin:
   - International
 Developer: Amir Farzad Forughi

--- a/records/pivlab.yaml
+++ b/records/pivlab.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Laboratory
+Cost: Free
 Country of Origin:
   - International
 Developer: William Thielicke

--- a/records/pom.yaml
+++ b/records/pom.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Description: |-
@@ -13,7 +14,7 @@ Discipline:
   - Site Characterization
 License Type:
   - Open-Source:
-    - GPL
+      - GPL
 Life Cycle:
   - Design
   - Operations and Maintenance

--- a/records/proteuscfd.yaml
+++ b/records/proteuscfd.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Nicholas Currier

--- a/records/pymap.yaml
+++ b/records/pymap.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Dependencies: MAP++

--- a/records/pyom2.yaml
+++ b/records/pyom2.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Carsten Eden

--- a/records/pypower.yaml
+++ b/records/pypower.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Richard Lincoln

--- a/records/pyseidon.yaml
+++ b/records/pyseidon.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Dependencies: FVCOM

--- a/records/pytides.yaml
+++ b/records/pytides.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Sam Cox

--- a/records/pyturbsim.yaml
+++ b/records/pyturbsim.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: NREL

--- a/records/pywafo.yaml
+++ b/records/pywafo.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Lund University

--- a/records/radwave.yaml
+++ b/records/radwave.yaml
@@ -1,6 +1,7 @@
 Collection Method:
   - Field
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Tristan Salles

--- a/records/raft.yaml
+++ b/records/raft.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: NREL

--- a/records/renewnet-foundary.yaml
+++ b/records/renewnet-foundary.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Description: |-

--- a/records/resourcecode.yaml
+++ b/records/resourcecode.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Description: |-

--- a/records/rex.yaml
+++ b/records/rex.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: NREL

--- a/records/robot-operating-system-ros.yaml
+++ b/records/robot-operating-system-ros.yaml
@@ -1,6 +1,7 @@
 Collection Method:
   - Field
   - Laboratory
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Open Robotics

--- a/records/roms-tidal-array.yaml
+++ b/records/roms-tidal-array.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Dependencies: ROMS/TOMS

--- a/records/roms-toms.yaml
+++ b/records/roms-toms.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Description: |-

--- a/records/salome.yaml
+++ b/records/salome.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Description: |-

--- a/records/snl-delft3d-cec.yaml
+++ b/records/snl-delft3d-cec.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Dependencies: Delft3D Flexible Mesh Suite

--- a/records/snl-swan.yaml
+++ b/records/snl-swan.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Dependencies: SWAN

--- a/records/sowfa.yaml
+++ b/records/sowfa.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Dependencies: OpenFOAM

--- a/records/suntans.yaml
+++ b/records/suntans.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Oliver Fringer

--- a/records/swan.yaml
+++ b/records/swan.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Description: |-

--- a/records/swash.yaml
+++ b/records/swash.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Description: |-

--- a/records/system-advisor-model-sam.yaml
+++ b/records/system-advisor-model-sam.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: NREL

--- a/records/tappy.yaml
+++ b/records/tappy.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Tim Cera & Pierre Cazenave

--- a/records/telemac-mascaret.yaml
+++ b/records/telemac-mascaret.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Description: |-

--- a/records/thermaltracker.yaml
+++ b/records/thermaltracker.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Field
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Pacific Northwest National Laboratory

--- a/records/thetis.yaml
+++ b/records/thetis.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Finnish Meteorological Institute

--- a/records/tidalresourceeval.yaml
+++ b/records/tidalresourceeval.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Ian Gagnon

--- a/records/tsdat.yaml
+++ b/records/tsdat.yaml
@@ -2,6 +2,7 @@ Collection Method:
   - Field
   - Laboratory
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: PNNL

--- a/records/university-of-miami-wave-model-umwm.yaml
+++ b/records/university-of-miami-wave-model-umwm.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: University of Miami

--- a/records/unobtrusive-multi-static-serial-lidar-imager-umsli-first-generation-shape-matching-based-classifier-for-2d-contours.yaml
+++ b/records/unobtrusive-multi-static-serial-lidar-imager-umsli-first-generation-shape-matching-based-classifier-for-2d-contours.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Field
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Description: |-
@@ -13,7 +14,7 @@ Discipline:
   - Environmental Impact
 License Type:
   - Open-Source:
-    - GPL
+      - GPL
 Life Cycle:
   - Condition Monitoring
   - Decommissioning

--- a/records/utide-matlab.yaml
+++ b/records/utide-matlab.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Description: |-

--- a/records/utide-python.yaml
+++ b/records/utide-python.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Wesley Bowman

--- a/records/veros.yaml
+++ b/records/veros.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Niels Bohr Institute, Copenhagen University

--- a/records/vessel-js.yaml
+++ b/records/vessel-js.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Norwegian University of Science and Technology

--- a/records/virocon.yaml
+++ b/records/virocon.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Andreas Haselsteiner

--- a/records/volttron.yaml
+++ b/records/volttron.yaml
@@ -1,6 +1,7 @@
 Collection Method:
   - Field
   - Laboratory
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Pacific Northwest National Laboratory

--- a/records/vort-transp.yaml
+++ b/records/vort-transp.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Description: |-

--- a/records/wafo.yaml
+++ b/records/wafo.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Lund University

--- a/records/wam.yaml
+++ b/records/wam.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Helmholtz-Zentrum Hereon
@@ -8,7 +9,7 @@ Discipline:
   - Site Characterization
 License Type:
   - Open-Source:
-    - GPL
+      - GPL
 Life Cycle:
   - Design
   - Operations and Maintenance

--- a/records/wattes.yaml
+++ b/records/wattes.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: Angus Creech

--- a/records/waveloads.yaml
+++ b/records/waveloads.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Ian Gagnon

--- a/records/wavespectra.yaml
+++ b/records/wavespectra.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Developer: MetOcean Solutions

--- a/records/wavewatch-iii.yaml
+++ b/records/wavewatch-iii.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: NOAA

--- a/records/wavy.yaml
+++ b/records/wavy.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Wavebit Scientific LLC

--- a/records/wdrt.yaml
+++ b/records/wdrt.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Sandia and NREL

--- a/records/wec-sim-applications.yaml
+++ b/records/wec-sim-applications.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Dependencies: WEC-Sim

--- a/records/wec-sim.yaml
+++ b/records/wec-sim.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Sandia and NREL

--- a/records/wecopttool.yaml
+++ b/records/wecopttool.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Developer: Sandia and NREL

--- a/records/xflr5.yaml
+++ b/records/xflr5.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - International
 Description: |-

--- a/records/xfoil.yaml
+++ b/records/xfoil.yaml
@@ -1,5 +1,6 @@
 Collection Method:
   - Modeling
+Cost: Free
 Country of Origin:
   - Domestic (USA)
 Description: |-

--- a/schema.yaml
+++ b/schema.yaml
@@ -417,6 +417,46 @@ properties:
     default: null
     description: The URL of the software package.
     title: Web Address
+allOf:
+  - if:
+      properties:
+        License Type:
+          required:
+            - Open-Source
+      required:
+        - License Type
+    then:
+      properties:
+        Cost:
+          const: Free
+      required:
+        - Cost
+  - if:
+      properties:
+        License Type:
+          contains:
+            const: Open-Source
+      required:
+        - License Type
+    then:
+      properties:
+        Cost:
+          const: Free
+      required:
+        - Cost
+  - if:
+      properties:
+        License Type:
+          contains:
+            const: Freeware
+      required:
+        - License Type
+    then:
+      properties:
+        Cost:
+          const: Free
+      required:
+        - Cost
 required:
 - Collection Method
 - Life Cycle

--- a/schema.yaml
+++ b/schema.yaml
@@ -421,8 +421,10 @@ allOf:
   - if:
       properties:
         License Type:
-          required:
-            - Open-Source
+          contains:
+            type: object
+            required:
+              - Open-Source
       required:
         - License Type
     then:


### PR DESCRIPTION
This PR adds `Cost: Free` to all records with `License Type` being `Freeware` or `Open-Source` (or some sub schema of `Open-Source`).

Additionally, the schema is updated to validate this requirement.
